### PR TITLE
Fixed inserting items into ItemHandlers with large slot capacities.

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets2/util/BuildingUtils.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/util/BuildingUtils.java
@@ -158,7 +158,7 @@ public class BuildingUtils {
                             for (int j = 0; j < slotHandler.getSlots(); j++) {
                                 ItemStack itemInBagSlot = slotHandler.getStackInSlot(j);
                                 if (ItemStack.isSameItem(itemInBagSlot, returnedItem))
-                                    slotHandler.insertItem(j, returnedItem.split(itemInBagSlot.getMaxStackSize() - itemInBagSlot.getCount()), false);
+                                    slotHandler.insertItem(j, returnedItem.split(slotHandler.getSlotLimit(i) - itemInBagSlot.getCount()), false);
                                 if (returnedItem.isEmpty()) return;
                             }
                         }
@@ -177,7 +177,7 @@ public class BuildingUtils {
                 for (int j = 0; j < handler.getSlots(); j++) {
                     ItemStack itemInSlot = handler.getStackInSlot(j);
                     if (ItemStack.isSameItem(itemInSlot, returnedItem))
-                        handler.insertItem(j, returnedItem.split(itemInSlot.getMaxStackSize() - itemInSlot.getCount()), false);
+                        handler.insertItem(j, returnedItem.split(handler.getSlotLimit(i) - itemInSlot.getCount()), false);
                     if (returnedItem.isEmpty()) break;
                 }
             }


### PR DESCRIPTION
This changes 2 lines in BuildingUtils, to base the split calculation off of the slot capacity, vs the max item stack size, Fixing interactions with item handlers with slots with capacities greater then the size of a stack.

Before this change, the gadgets would give you free items of count (63 - current_stack_size_in_handler) absoluted, and multiplied by the number of incoming items.