### PR TITLE
Handles range key as rotate on Paste Gadgets

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets2/client/events/EventKeyInput.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/client/events/EventKeyInput.java
@@ -5,14 +5,18 @@ import com.direwolf20.buildinggadgets2.client.KeyBindings;
 import com.direwolf20.buildinggadgets2.client.screen.DestructionGUI;
 import com.direwolf20.buildinggadgets2.client.screen.ModeRadialMenu;
 import com.direwolf20.buildinggadgets2.common.items.BaseGadget;
+import com.direwolf20.buildinggadgets2.common.items.GadgetCopyPaste;
+import com.direwolf20.buildinggadgets2.common.items.GadgetCutPaste;
 import com.direwolf20.buildinggadgets2.common.items.GadgetDestruction;
 import com.direwolf20.buildinggadgets2.common.network.PacketHandler;
 import com.direwolf20.buildinggadgets2.common.network.packets.PacketAnchor;
 import com.direwolf20.buildinggadgets2.common.network.packets.PacketRangeChange;
+import com.direwolf20.buildinggadgets2.common.network.packets.PacketRotate;
 import com.direwolf20.buildinggadgets2.common.network.packets.PacketUndo;
 import com.direwolf20.buildinggadgets2.util.GadgetNBT;
 import net.minecraft.client.KeyMapping;
 import net.minecraft.client.Minecraft;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.client.settings.KeyModifier;
@@ -51,9 +55,14 @@ public class EventKeyInput {
         } else if (KeyBindings.anchor.consumeClick()) {
             PacketHandler.sendToServer(new PacketAnchor());
         } else if (KeyBindings.range.consumeClick()) {
-            int oldRange = GadgetNBT.getToolRange(tool);
-            int newRange = oldRange + 1 > 15 ? 1 : oldRange + 1;
-            PacketHandler.sendToServer(new PacketRangeChange(newRange));
+            Item toolItem = tool.getItem();
+            if (toolItem instanceof GadgetCopyPaste || toolItem instanceof GadgetCutPaste) {
+                PacketHandler.sendToServer(new PacketRotate());
+            } else {
+                int oldRange = GadgetNBT.getToolRange(tool);
+                int newRange = oldRange + 1 > 15 ? 1 : oldRange + 1;
+                PacketHandler.sendToServer(new PacketRangeChange(newRange));
+            }
         }/*else if (KeyBindings.rotateMirror.consumeClick()) {
             PacketHandler.sendToServer(new PacketRotateMirror());
         } else if (KeyBindings.undo.consumeClick()) {


### PR DESCRIPTION
It's a simple change, I figured I would start with this.

The Range key modifier is unused in the Copy-Paste and Cut-Paste gadgets, which would benefit from a rotation key.
This was tested on the default client configuration generated by gradle.