### PR TITLE
Add mirror binding on paste gadgets

### DIFF
--- a/src/generated/resources/assets/buildinggadgets2/lang/en_us.json
+++ b/src/generated/resources/assets/buildinggadgets2/lang/en_us.json
@@ -101,6 +101,7 @@
   "key.buildinggadgets2.anchor": "Anchor",
   "key.buildinggadgets2.category": "Building Gadgets 2",
   "key.buildinggadgets2.range": "Range",
+  "key.buildinggadgets2.rotate_mirror": "Mirror",
   "key.buildinggadgets2.settings_menu": "Settings Menu",
   "key.buildinggadgets2.undo": "Undo"
 }

--- a/src/main/java/com/direwolf20/buildinggadgets2/client/KeyBindings.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/client/KeyBindings.java
@@ -32,6 +32,7 @@ public class KeyBindings {
     public static KeyMapping undo = createBinding("undo", GLFW.GLFW_KEY_U);
     public static KeyMapping anchor = createBinding("anchor", GLFW.GLFW_KEY_H);
     public static KeyMapping range = createBinding("range", GLFW.GLFW_KEY_R);
+    public static KeyMapping rotateMirror = createBinding("rotate_mirror", GLFW.GLFW_KEY_UNKNOWN);
 
     private static KeyMapping createBinding(String name, int key) {
         KeyMapping keyBinding = new KeyMapping(getKey(name), CONFLICT_CONTEXT_GADGET, InputConstants.Type.KEYSYM.getOrCreate(key), getKey("category"));

--- a/src/main/java/com/direwolf20/buildinggadgets2/client/events/EventKeyInput.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/client/events/EventKeyInput.java
@@ -5,10 +5,13 @@ import com.direwolf20.buildinggadgets2.client.KeyBindings;
 import com.direwolf20.buildinggadgets2.client.screen.DestructionGUI;
 import com.direwolf20.buildinggadgets2.client.screen.ModeRadialMenu;
 import com.direwolf20.buildinggadgets2.common.items.BaseGadget;
+import com.direwolf20.buildinggadgets2.common.items.GadgetCopyPaste;
+import com.direwolf20.buildinggadgets2.common.items.GadgetCutPaste;
 import com.direwolf20.buildinggadgets2.common.items.GadgetDestruction;
 import com.direwolf20.buildinggadgets2.common.network.PacketHandler;
 import com.direwolf20.buildinggadgets2.common.network.packets.PacketAnchor;
 import com.direwolf20.buildinggadgets2.common.network.packets.PacketRangeChange;
+import com.direwolf20.buildinggadgets2.common.network.packets.PacketRotateMirror;
 import com.direwolf20.buildinggadgets2.common.network.packets.PacketUndo;
 import com.direwolf20.buildinggadgets2.util.GadgetNBT;
 import net.minecraft.client.KeyMapping;
@@ -54,13 +57,10 @@ public class EventKeyInput {
             int oldRange = GadgetNBT.getToolRange(tool);
             int newRange = oldRange + 1 > 15 ? 1 : oldRange + 1;
             PacketHandler.sendToServer(new PacketRangeChange(newRange));
-        }/*else if (KeyBindings.rotateMirror.consumeClick()) {
-            PacketHandler.sendToServer(new PacketRotateMirror());
-        } else if (KeyBindings.undo.consumeClick()) {
-            PacketHandler.sendToServer(new PacketUndo());
-        } else if (KeyBindings.anchor.consumeClick()) {
-            PacketHandler.sendToServer(new PacketAnchor());
-        } else if (KeyBindings.fuzzy.consumeClick()) {
+        } else if (KeyBindings.rotateMirror.consumeClick()) {
+            if (tool.getItem() instanceof GadgetCopyPaste || tool.getItem() instanceof GadgetCutPaste)
+                PacketHandler.sendToServer(new PacketRotateMirror());
+        }/*else if (KeyBindings.fuzzy.consumeClick()) {
             PacketHandler.sendToServer(new PacketToggleFuzzy());
         } else if (KeyBindings.connectedArea.consumeClick()) {
             PacketHandler.sendToServer(new PacketToggleConnectedArea());

--- a/src/main/java/com/direwolf20/buildinggadgets2/common/network/PacketHandler.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/common/network/PacketHandler.java
@@ -43,6 +43,7 @@ public class PacketHandler {
         HANDLER.registerMessage(id++, PacketSendCopyDataToServer.class, PacketSendCopyDataToServer::encode, PacketSendCopyDataToServer::decode, PacketSendCopyDataToServer::handle);
         HANDLER.registerMessage(id++, PacketSendPasteBatches.class, PacketSendPasteBatches::encode, PacketSendPasteBatches::decode, PacketSendPasteBatches::handle);
         HANDLER.registerMessage(id++, PacketRotate.class, PacketRotate::encode, PacketRotate::decode, PacketRotate::handle);
+        HANDLER.registerMessage(id++, PacketRotateMirror.class, PacketRotateMirror::encode, PacketRotateMirror::decode, PacketRotateMirror::handle);
 
         //Client Side
         HANDLER.registerMessage(id++, PacketSendCopyData.class, PacketSendCopyData::encode, PacketSendCopyData::decode, PacketSendCopyData.Handler::handle);

--- a/src/main/java/com/direwolf20/buildinggadgets2/common/network/packets/PacketRotateMirror.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/common/network/packets/PacketRotateMirror.java
@@ -1,0 +1,69 @@
+package com.direwolf20.buildinggadgets2.common.network.packets;
+
+import com.direwolf20.buildinggadgets2.common.events.ServerTickHandler;
+import com.direwolf20.buildinggadgets2.common.items.BaseGadget;
+import com.direwolf20.buildinggadgets2.common.items.GadgetCutPaste;
+import com.direwolf20.buildinggadgets2.common.worlddata.BG2Data;
+import com.direwolf20.buildinggadgets2.util.GadgetNBT;
+import com.direwolf20.buildinggadgets2.util.datatypes.StatePos;
+import com.direwolf20.buildinggadgets2.util.datatypes.TagPos;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.ArrayList;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.function.Supplier;
+
+public class PacketRotateMirror {
+    public PacketRotateMirror() {
+    }
+
+    public static PacketRotateMirror decode(FriendlyByteBuf buf) {
+        return new PacketRotateMirror();
+    }
+
+    public static void encode(PacketRotateMirror message, FriendlyByteBuf buf) {
+
+    }
+
+    public static void handle(PacketRotateMirror message, Supplier<NetworkEvent.Context> context) {
+        context.get().enqueueWork(() -> {
+            ServerPlayer sender = context.get().getSender();
+            if (sender == null) {
+                return;
+            }
+
+            ItemStack gadget = BaseGadget.getGadget(sender);
+            if (gadget.isEmpty() || !(gadget.getItem() instanceof BaseGadget actualGadget)) {
+                return;
+            }
+            UUID gadgetUUID = GadgetNBT.getUUID(gadget);
+            if (gadget.getItem() instanceof GadgetCutPaste) {
+                if (ServerTickHandler.gadgetWorking(gadgetUUID)) {
+                    sender.displayClientMessage(Component.translatable("buildinggadgets2.messages.cutinprogress"), true);
+                    return; //If the gadget is mid cut, don't sync data
+                }
+            }
+
+            BG2Data bg2Data = BG2Data.get(Objects.requireNonNull(sender.level().getServer()).overworld());
+
+            ArrayList<StatePos> currentPosList = bg2Data.getCopyPasteList(gadgetUUID, false);
+            ArrayList<TagPos> tagListMutable = bg2Data.peekTEMap(gadgetUUID);
+
+            ArrayList<StatePos> newPosList = StatePos.mirror(currentPosList, tagListMutable);
+
+            bg2Data.addToCopyPaste(gadgetUUID, newPosList);
+            GadgetNBT.setCopyUUID(gadget);
+
+            //Handle TE Data - do nothing if null or empty
+            if (tagListMutable == null || tagListMutable.isEmpty()) return;
+            bg2Data.addToTEMap(gadgetUUID, tagListMutable);
+        });
+
+        context.get().setPacketHandled(true);
+    }
+}

--- a/src/main/resources/assets/buildinggadgets2/lang/zh_cn.json
+++ b/src/main/resources/assets/buildinggadgets2/lang/zh_cn.json
@@ -100,6 +100,7 @@
   "key.buildinggadgets2.anchor": "预览锁定",
   "key.buildinggadgets2.category": "建筑小帮手2",
   "key.buildinggadgets2.range": "范围调节",
+  "key.buildinggadgets2.rotate_mirror": "反射",
   "key.buildinggadgets2.settings_menu": "设置菜单",
   "key.buildinggadgets2.undo": "撤销"
 }


### PR DESCRIPTION
This one is a little more involved, but nothing too complicated.

Building Gadgets 1 has a mirror action on Copy-Paste and Cut-Paste gadgets when in Paste mode. This adds it back.
This was tested on the default client generated by gradle.

Some notes :
 - I don't really like the code duplication I did from PacketRotate to PacketMirror, but refactoring code so that it is reusable may be a bit too ambitious for my first few PRs. I can rework it if you want me to.
 - I noticed there were Simplified Chinese translations, and I don't speak a word of Chinese. I used [Word Reference](https://www.wordreference.com/enzh/mirror) to translate it and picked what seemed the most sensible option, but it's probably still wrong. I can remove the translation line entirely if you would rather have no translation than a bad one.