### PR TITLE
Enhanced copy and paste with TileEntity data

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -23,7 +23,7 @@ loader_version_range=[2,)
 #Mod Info
 mod_id=buildinggadgets2
 mod_name=Building Gadgets 2
-mod_version=1.3.9
+mod_version=1.3.10
 mod_license=MIT
 mod_authors=direwolf20
 mod_group_id=com.direwolf20.buildinggadgets2

--- a/src/main/java/com/direwolf20/buildinggadgets2/common/events/ServerBuildList.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/common/events/ServerBuildList.java
@@ -40,6 +40,7 @@ public class ServerBuildList {
     public BlockPos lookingAt = BlockPos.ZERO;
     public GlobalPos boundPos;
     public int direction;
+    public boolean isCopyPasteWithTEData = false;
 
     public ServerBuildList(Level level, ArrayList<StatePos> statePosList, byte renderType, UUID playerUUID, boolean needItems, boolean returnItems, UUID buildUUID, ItemStack gadget, BuildType buildType, boolean dropContents, BlockPos lookingAt, GlobalPos boundPos, int direction) {
         this.level = level;

--- a/src/main/java/com/direwolf20/buildinggadgets2/common/events/ServerTickHandler.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/common/events/ServerTickHandler.java
@@ -78,6 +78,13 @@ public class ServerTickHandler {
         serverBuildList.teData = teData;
     }
 
+    public static void addTEDataForCopyPaste(UUID buildUUID, ArrayList<TagPos> teData) {
+        ServerBuildList serverBuildList = buildMap.get(buildUUID);
+        if (serverBuildList == null) return;
+        serverBuildList.teData = teData;
+        serverBuildList.isCopyPasteWithTEData = true;
+    }
+
     public static boolean gadgetWorking(UUID gadgetUUID) {
         return buildMap.values().stream().anyMatch(e -> GadgetNBT.getUUID(e.gadget).equals(gadgetUUID));
     }
@@ -104,7 +111,7 @@ public class ServerTickHandler {
             ServerBuildList serverBuildList = entry.getValue();
             if (entry.getValue().statePosList.isEmpty()) {
                 Player player = event.getServer().getPlayerList().getPlayer(serverBuildList.playerUUID); //We check for the player - if they exist, they finished building - if not they logged off. Remove data from map only if finished building
-                if (serverBuildList.teData != null && !serverBuildList.buildType.equals(ServerBuildList.BuildType.CUT) && player != null) { //If we had teData this was from a cut-Paste, so remove the data from world data if we're not cutting
+                if (serverBuildList.teData != null && !serverBuildList.buildType.equals(ServerBuildList.BuildType.CUT) && !serverBuildList.isCopyPasteWithTEData && player != null) { //If we had teData this was from a cut-Paste, so remove the data from world data if we're not cutting (and not copy-paste with TE data)
                     BG2Data bg2Data = BG2Data.get(Objects.requireNonNull(serverBuildList.level.getServer()).overworld());
                     bg2Data.getCopyPasteList(GadgetNBT.getUUID(serverBuildList.gadget), true); //Remove the data
                     bg2Data.getTEMap(GadgetNBT.getUUID(serverBuildList.gadget)); //Remove the TE data
@@ -149,7 +156,9 @@ public class ServerTickHandler {
             return;
         }
 
-        if (!level.getBlockState(blockPos).canBeReplaced()) return; //Return without placing the block
+        if (!level.getBlockState(blockPos).canBeReplaced()) {
+            return; //Return without placing the block
+        }
 
         List<ItemStack> neededItems = GadgetUtils.getDropsForBlockState((ServerLevel) level, blockPos, blockState, player);
         if (blockState.getFluidState().isEmpty()) { //Check for items
@@ -198,13 +207,18 @@ public class ServerTickHandler {
             bg2Data.addToUndoList(serverBuildList.buildUUID, serverBuildList.actuallyBuildList, level);
         }
 
-        if (serverBuildList.teData != null) { //If theres ANY TE data (even an empty list), we are doing a cut paste
-            serverBuildList.addToBuiltList(new StatePos(blockState, statePos.pos)); //Add the non-adjust blockpos to the list for reference later
-            bg2Data.addToUndoList(GadgetNBT.getUUID(serverBuildList.gadget), serverBuildList.actuallyBuildList, level);
-
+        if (serverBuildList.teData != null) { //If theres ANY TE data (even an empty list), we are doing a cut paste or copy paste with TE data
             CompoundTag compoundTag = serverBuildList.getTagForPos(blockPos); //First check if theres TE data for this block
             if (!compoundTag.isEmpty()) {
                 be.setBlockEntityData(compoundTag);
+            }
+            
+            if (serverBuildList.isCopyPasteWithTEData) {
+                serverBuildList.addToBuiltList(new StatePos(blockState, blockPos));
+                bg2Data.addToUndoList(serverBuildList.buildUUID, serverBuildList.actuallyBuildList, level);
+            } else {
+                serverBuildList.addToBuiltList(new StatePos(blockState, statePos.pos)); //Add the non-adjust blockpos to the list for reference later
+                bg2Data.addToUndoList(GadgetNBT.getUUID(serverBuildList.gadget), serverBuildList.actuallyBuildList, level);
                 bg2Data.addToTEMap(GadgetNBT.getUUID(serverBuildList.gadget), serverBuildList.teData); //If the server crashes mid-build you'll maybe dupe blocks but at least not dupe TE data? TODO Improve
             }
         }
@@ -340,13 +354,18 @@ public class ServerTickHandler {
             serverBuildList.addToBuiltList(new StatePos(oldState, blockPos));
             bg2Data.addToUndoList(serverBuildList.buildUUID, serverBuildList.actuallyBuildList, level);
         }
-        if (serverBuildList.teData != null) { //If theres ANY TE data (even an empty list), we are doing a cut paste
-            serverBuildList.addToBuiltList(new StatePos(blockState, statePos.pos)); //Add the non-adjust blockpos to the list for reference later
-            bg2Data.addToUndoList(GadgetNBT.getUUID(serverBuildList.gadget), serverBuildList.actuallyBuildList, level);
-
+        if (serverBuildList.teData != null) { //If theres ANY TE data (even an empty list), we are doing a cut paste or copy paste with TE data
             CompoundTag compoundTag = serverBuildList.getTagForPos(blockPos); //First check if theres TE data for this block
             if (!compoundTag.isEmpty()) {
                 be.setBlockEntityData(compoundTag);
+            }
+            
+            if (serverBuildList.isCopyPasteWithTEData) {
+                serverBuildList.addToBuiltList(new StatePos(oldState, blockPos));
+                bg2Data.addToUndoList(serverBuildList.buildUUID, serverBuildList.actuallyBuildList, level);
+            } else {
+                serverBuildList.addToBuiltList(new StatePos(blockState, statePos.pos)); //Add the non-adjust blockpos to the list for reference later
+                bg2Data.addToUndoList(GadgetNBT.getUUID(serverBuildList.gadget), serverBuildList.actuallyBuildList, level);
                 bg2Data.addToTEMap(GadgetNBT.getUUID(serverBuildList.gadget), serverBuildList.teData); //If the server crashes mid-build you'll maybe dupe blocks but at least not dupe TE data? TODO Improve
             }
         }

--- a/src/main/java/com/direwolf20/buildinggadgets2/common/items/GadgetCopyPaste.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/common/items/GadgetCopyPaste.java
@@ -8,6 +8,7 @@ import com.direwolf20.buildinggadgets2.util.GadgetNBT;
 import com.direwolf20.buildinggadgets2.util.GadgetUtils;
 import com.direwolf20.buildinggadgets2.util.context.ItemActionContext;
 import com.direwolf20.buildinggadgets2.util.datatypes.StatePos;
+import com.direwolf20.buildinggadgets2.util.datatypes.TagPos;
 import com.direwolf20.buildinggadgets2.util.modes.Copy;
 import com.direwolf20.buildinggadgets2.util.modes.Paste;
 import net.minecraft.ChatFormatting;
@@ -78,13 +79,18 @@ public class GadgetCopyPaste extends BaseGadget {
             UUID uuid = GadgetNBT.getUUID(gadget);
             BG2Data bg2Data = BG2Data.get(Objects.requireNonNull(context.player().level().getServer()).overworld());
             ArrayList<StatePos> buildList = bg2Data.getCopyPasteList(uuid, false);
+            ArrayList<TagPos> tagList = bg2Data.peekTEMap(uuid);
+            
             UUID buildUUID;
-            boolean replace = GadgetNBT.getPasteReplace(gadget);
-            if (!replace)
-                buildUUID = BuildingUtils.build(context.level(), context.player(), buildList, getHitPos(context).above().offset(GadgetNBT.getRelativePaste(gadget)), gadget, true);
-            else
-                buildUUID = BuildingUtils.exchange(context.level(), context.player(), buildList, getHitPos(context).above().offset(GadgetNBT.getRelativePaste(gadget)), gadget, true, false);
-
+            if (tagList != null && !tagList.isEmpty()) {
+                buildUUID = BuildingUtils.buildCopyPasteWithTileData(context.level(), context.player(), buildList, getHitPos(context).above().offset(GadgetNBT.getRelativePaste(gadget)), tagList, gadget);
+            } else {
+                boolean replace = GadgetNBT.getPasteReplace(gadget);
+                if (!replace)
+                    buildUUID = BuildingUtils.build(context.level(), context.player(), buildList, getHitPos(context).above().offset(GadgetNBT.getRelativePaste(gadget)), gadget, true);
+                else
+                    buildUUID = BuildingUtils.exchange(context.level(), context.player(), buildList, getHitPos(context).above().offset(GadgetNBT.getRelativePaste(gadget)), gadget, true, false);
+            }
             GadgetUtils.addToUndoList(context.level(), gadget, new ArrayList<>(), buildUUID);
             //GadgetNBT.clearAnchorPos(gadget);
             return InteractionResultHolder.success(gadget);
@@ -116,11 +122,14 @@ public class GadgetCopyPaste extends BaseGadget {
     }
 
     public void buildAndStore(ItemActionContext context, ItemStack gadget) {
-        ArrayList<StatePos> buildList = new Copy().collect(context.hitResult().getDirection(), context.player(), context.pos(), Blocks.AIR.defaultBlockState());
+        Copy copyMode = new Copy();
+        ArrayList<StatePos> buildList = copyMode.collect(context.hitResult().getDirection(), context.player(), context.pos(), Blocks.AIR.defaultBlockState());
+        ArrayList<TagPos> teData = copyMode.getCollectedTEData();
         UUID uuid = GadgetNBT.getUUID(gadget);
         GadgetNBT.setCopyUUID(gadget); //This UUID will be used to determine if the copy/paste we are rendering from the cache is old or not.
         BG2Data bg2Data = BG2Data.get(Objects.requireNonNull(context.player().level().getServer()).overworld());
         bg2Data.addToCopyPaste(uuid, buildList);
+        bg2Data.addToTEMap(uuid, teData);
         context.player().displayClientMessage(Component.translatable("buildinggadgets2.messages.copyblocks", buildList.size()), true);
     }
 

--- a/src/main/java/com/direwolf20/buildinggadgets2/util/BuildingUtils.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/util/BuildingUtils.java
@@ -530,6 +530,24 @@ public class BuildingUtils {
         return actuallyBuiltList;
     }
 
+    public static UUID buildCopyPasteWithTileData(Level level, Player player, ArrayList<StatePos> blockPosList, BlockPos lookingAt, ArrayList<TagPos> teData, ItemStack gadget) {
+        UUID buildUUID;
+        boolean replace = GadgetNBT.getPasteReplace(gadget);
+        if (!replace)
+            buildUUID = BuildingUtils.build(level, player, blockPosList, lookingAt, gadget, true);
+        else
+            buildUUID = BuildingUtils.exchange(level, player, blockPosList, lookingAt, gadget, true, false);
+
+        if (teData != null && !teData.isEmpty()) {
+            ArrayList<TagPos> teDataCopy = new ArrayList<>();
+            for (TagPos tagPos : teData) {
+                teDataCopy.add(new TagPos(tagPos.tag.copy(), tagPos.pos));
+            }
+            ServerTickHandler.addTEDataForCopyPaste(buildUUID, teDataCopy);
+        }
+        return buildUUID;
+    }
+
     public static UUID removeTickHandler(Level level, Player player, List<BlockPos> blockPosList, boolean giveItem, boolean dropContents, ItemStack gadget) {
         UUID buildUUID = UUID.randomUUID();
         for (BlockPos pos : blockPosList) {

--- a/src/main/java/com/direwolf20/buildinggadgets2/util/modes/Copy.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/util/modes/Copy.java
@@ -8,14 +8,17 @@ import com.direwolf20.buildinggadgets2.util.GadgetNBT;
 import com.direwolf20.buildinggadgets2.util.GadgetUtils;
 import com.direwolf20.buildinggadgets2.util.VecHelpers;
 import com.direwolf20.buildinggadgets2.util.datatypes.StatePos;
+import com.direwolf20.buildinggadgets2.util.datatypes.TagPos;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Blocks;
+import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.phys.AABB;
 
@@ -23,8 +26,14 @@ import java.util.ArrayList;
 import java.util.stream.Stream;
 
 public class Copy extends BaseMode {
+    private ArrayList<TagPos> collectedTEData = new ArrayList<>();
+    
     public Copy() {
         super(false);
+    }
+    
+    public ArrayList<TagPos> getCollectedTEData() {
+        return collectedTEData;
     }
 
     @Override
@@ -35,6 +44,7 @@ public class Copy extends BaseMode {
     @Override
     public ArrayList<StatePos> collectWorld(Direction hitSide, Player player, BlockPos start, BlockState state) {
         ArrayList<StatePos> coordinates = new ArrayList<>();
+        collectedTEData = new ArrayList<>();
         ItemStack heldItem = BaseGadget.getGadget(player);
         if (!(heldItem.getItem() instanceof GadgetCopyPaste)) return coordinates; //Impossible....right?
         Level level = player.level();
@@ -65,10 +75,22 @@ public class Copy extends BaseMode {
             return coordinates;
         }
         BlockPos.betweenClosedStream(area).map(BlockPos::immutable).forEach(pos -> {
-            if (GadgetUtils.isValidBlockState(level.getBlockState(pos), level, pos) && !(level.getBlockState(pos).getBlock() instanceof RenderBlock))
-                coordinates.add(new StatePos(GadgetUtils.cleanBlockState(level.getBlockState(pos)), pos.subtract(copyStart)));
-            else
+            BlockState blockState = level.getBlockState(pos);
+            boolean isValid = GadgetUtils.isValidBlockState(blockState, level, pos);
+            boolean isRenderBlock = blockState.getBlock() instanceof RenderBlock;
+            
+            if (isValid && !isRenderBlock) {
+                coordinates.add(new StatePos(GadgetUtils.cleanBlockState(blockState), pos.subtract(copyStart)));
+                
+                BlockEntity blockEntity = level.getBlockEntity(pos);
+                if (blockEntity != null) {
+                    CompoundTag blockTag = blockEntity.saveWithFullMetadata(level.registryAccess());
+                    TagPos tagPos = new TagPos(blockTag, pos.subtract(copyStart));
+                    collectedTEData.add(tagPos);
+                }
+            } else {
                 coordinates.add(new StatePos(Blocks.AIR.defaultBlockState(), pos.subtract(copyStart))); //We need to have a block in EVERY position, so write air if invalid
+            }
         });
         return coordinates;
     }


### PR DESCRIPTION
## Branch Summary
This PR addresses issues with missing blocks during copy/paste operations, particularly with blocks that have TileEntity (BlockEntity) data like Mekanism blocks. The flow is similar to cut/paste where it retains TE.

## Summary of Bug Fix

The core issue was that copy-paste operations were not preserving BlockEntity (TileEntity) data, causing blocks like Mekanism machines to lose their configuration when pasted.

**The fix involves:**
1. **Copy phase:** Collect and store BlockEntity NBT data alongside block states
2. **Storage:** Store TE data in BG2Data world data (via `addToTEMap`)
3. **Paste phase:** Detect when TE data exists and use dedicated copy-paste flow
4. **Placement:** Apply TE data to newly placed blocks via `RenderBlockBE.setBlockEntityData()`
5. **Undo tracking:** Properly track copy-paste operations separately from cut-paste

## Tested primarily with Mekanism but I assume TE data would be an issue for other mods with similar data structures

Paste before fix, most connections are removed and also all the mekanism block configurations reset to blank inputs:
<img width="854" height="480" alt="2026-01-28_15 09 42" src="https://github.com/user-attachments/assets/2f4f56bd-1faa-42c8-a9e8-7e2253416ec8" />

Paste after fix, machine remains intact:
<img width="854" height="480" alt="2026-01-28_15 11 38" src="https://github.com/user-attachments/assets/8ecdd5b2-e73c-492c-89bc-aed5a75c0a1c" />

## Issues to be addressed as per this fix, possibly many more

- #224 
- #222 
- #174 