### PR TITLE
Add AE2 storage counts to material list when bound to wireless access…

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets2/client/screen/MaterialListGUI.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/client/screen/MaterialListGUI.java
@@ -14,6 +14,7 @@ import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.util.Mth;
 import net.minecraft.world.item.ItemStack;
+import com.direwolf20.buildinggadgets2.common.network.packets.PacketUpdateAE2Count;
 
 public class MaterialListGUI extends Screen {
 
@@ -221,5 +222,15 @@ public class MaterialListGUI extends Screen {
                 y >= by &&
                 x < bx + width &&
                 y < by + height;
+    }
+
+    public ScrollingMaterialList getScrollingList() {
+        return scrollingList;
+    }
+
+    @Override
+    public void onClose() {
+        PacketUpdateAE2Count.clientCache.clear(); // so next time we open we don't show old numbers
+        super.onClose();
     }
 }

--- a/src/main/java/com/direwolf20/buildinggadgets2/client/screen/widgets/ScrollingMaterialList.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/client/screen/widgets/ScrollingMaterialList.java
@@ -5,6 +5,7 @@ import com.direwolf20.buildinggadgets2.common.worlddata.BG2DataClient;
 import com.direwolf20.buildinggadgets2.util.BuildingUtils;
 import com.direwolf20.buildinggadgets2.util.GadgetNBT;
 import com.direwolf20.buildinggadgets2.util.ItemStackKey;
+import com.direwolf20.buildinggadgets2.util.DimBlockPos;
 import com.direwolf20.buildinggadgets2.util.datatypes.StatePos;
 import com.mojang.blaze3d.platform.Lighting;
 import com.mojang.blaze3d.systems.RenderSystem;
@@ -102,8 +103,9 @@ public class ScrollingMaterialList extends EntryList<ScrollingMaterialList.Entry
             addEntry(new Entry(this, stack, entry.getValue(), totalAvailable));
         }
 
-        if (!stacksToRequest.isEmpty()) {
-            PacketHandler.sendToServer(new PacketRequestAE2Count(GadgetNBT.getBoundPos(templateItem), stacksToRequest));
+        DimBlockPos boundPos = GadgetNBT.getBoundPos(templateItem);
+        if (boundPos != null && !stacksToRequest.isEmpty()) {
+            PacketHandler.sendToServer(new PacketRequestAE2Count(boundPos, stacksToRequest));
         }
 
         sort();

--- a/src/main/java/com/direwolf20/buildinggadgets2/client/screen/widgets/ScrollingMaterialList.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/client/screen/widgets/ScrollingMaterialList.java
@@ -29,6 +29,11 @@ import static com.direwolf20.buildinggadgets2.client.screen.MaterialListGUI.*;
 import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA;
 import static org.lwjgl.opengl.GL11.GL_SRC_ALPHA;
 
+import net.minecraftforge.registries.ForgeRegistries;
+import com.direwolf20.buildinggadgets2.common.network.PacketHandler;
+import com.direwolf20.buildinggadgets2.common.network.packets.PacketRequestAE2Count;
+import com.direwolf20.buildinggadgets2.common.network.packets.PacketUpdateAE2Count;
+
 // Todo change to AbstractList as it's an easy fix compared to duping the class
 public class ScrollingMaterialList extends EntryList<ScrollingMaterialList.Entry> {
     private static final int UPDATE_MILLIS = 1000;
@@ -73,25 +78,32 @@ public class ScrollingMaterialList extends EntryList<ScrollingMaterialList.Entry
         this.clearEntries();
         this.setScrollAmount(0);
 
-        //Get the statePos list - since this screen can only be called from 'paste' mode, the client side should always be up to date in theory?
         if (statePosArrayList == null || statePosArrayList.isEmpty()) {
             statePosArrayList = BG2DataClient.getLookupFromUUID(GadgetNBT.getUUID(templateItem));
         }
 
         Player player = Minecraft.getInstance().player;
+        if (player == null) return;
 
-        // Could likely just assert
-        if (player == null)
-            return;
-
-        //Get a list of ItemStackkey -> Amount required (Integer)
         itemCountsMap = StatePos.getItemList(statePosArrayList);
+        List<ItemStack> stacksToRequest = new ArrayList<>();
 
+        // Use cache for AE2 counts (empty first time, then filled when the response gets back). One packet for all items.
         for (Map.Entry<ItemStackKey, Integer> entry : itemCountsMap.entrySet()) {
-            if (entry.getKey().getStack().isEmpty()) continue;
-            int itemCount = BuildingUtils.countItemStacks(player, entry.getKey().getStack());
-            //Add entries to the list
-            addEntry(new Entry(this, entry.getKey().getStack(), entry.getValue(), itemCount));
+            ItemStack stack = entry.getKey().getStack();
+            if (stack.isEmpty()) continue;
+
+            stacksToRequest.add(stack);
+
+            String itemKey = ForgeRegistries.ITEMS.getKey(stack.getItem()).toString();
+            int ae2Count = PacketUpdateAE2Count.clientCache.getOrDefault(itemKey, 0);
+
+            int totalAvailable = BuildingUtils.countItemStacks(player, stack) + ae2Count;
+            addEntry(new Entry(this, stack, entry.getValue(), totalAvailable));
+        }
+
+        if (!stacksToRequest.isEmpty()) {
+            PacketHandler.sendToServer(new PacketRequestAE2Count(GadgetNBT.getBoundPos(templateItem), stacksToRequest));
         }
 
         sort();
@@ -159,6 +171,10 @@ public class ScrollingMaterialList extends EntryList<ScrollingMaterialList.Entry
             this.widthAmount = Minecraft.getInstance().font.width(amount);
         }
 
+        public void updateAmountString() {
+            this.amount = Math.min(this.available, this.required) + "/" + required;
+        }
+
         @Override
         public void render(GuiGraphics guiGraphics, int index, int topY, int leftX, int entryWidth, int entryHeight, int mouseX, int mouseY, boolean hovered, float particleTicks) {
             // Weird render issue with GuiSlot where the right border is slightly offset
@@ -220,7 +236,7 @@ public class ScrollingMaterialList extends EntryList<ScrollingMaterialList.Entry
         }
 
         private boolean hasEnoughItems() {
-            return required == available;
+            return required <= available;
         }
 
         private int getTextColor() {
@@ -327,5 +343,19 @@ public class ScrollingMaterialList extends EntryList<ScrollingMaterialList.Entry
         }
 
         public static final SortingModes[] VALUES = SortingModes.values();
+    }
+
+    // When the AE2 count packet comes back, update the right row so it shows player + AE2.
+    public void refreshItemCount(String itemKey, int newCount) {
+        for (Entry entry : this.children()) {
+            String entryKey = net.minecraftforge.registries.ForgeRegistries.ITEMS.getKey(entry.stack.getItem()).toString();
+            if (entryKey.equals(itemKey)) {
+                Player player = Minecraft.getInstance().player;
+                int playerInvCount = BuildingUtils.countItemStacks(player, entry.stack);
+                entry.available = playerInvCount + newCount; 
+                entry.updateAmountString(); 
+                return; 
+            }
+        }
     }
 }

--- a/src/main/java/com/direwolf20/buildinggadgets2/common/network/PacketHandler.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/common/network/PacketHandler.java
@@ -43,6 +43,8 @@ public class PacketHandler {
         HANDLER.registerMessage(id++, PacketSendCopyDataToServer.class, PacketSendCopyDataToServer::encode, PacketSendCopyDataToServer::decode, PacketSendCopyDataToServer::handle);
         HANDLER.registerMessage(id++, PacketSendPasteBatches.class, PacketSendPasteBatches::encode, PacketSendPasteBatches::decode, PacketSendPasteBatches::handle);
         HANDLER.registerMessage(id++, PacketRotate.class, PacketRotate::encode, PacketRotate::decode, PacketRotate::handle);
+        HANDLER.registerMessage(id++, PacketRequestAE2Count.class, PacketRequestAE2Count::encode, PacketRequestAE2Count::decode, PacketRequestAE2Count::handle);
+        HANDLER.registerMessage(id++, PacketUpdateAE2Count.class, PacketUpdateAE2Count::encode, PacketUpdateAE2Count::decode, PacketUpdateAE2Count::handle);
 
         //Client Side
         HANDLER.registerMessage(id++, PacketSendCopyData.class, PacketSendCopyData::encode, PacketSendCopyData::decode, PacketSendCopyData.Handler::handle);

--- a/src/main/java/com/direwolf20/buildinggadgets2/common/network/packets/PacketRequestAE2Count.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/common/network/packets/PacketRequestAE2Count.java
@@ -1,0 +1,66 @@
+package com.direwolf20.buildinggadgets2.common.network.packets;
+
+import com.direwolf20.buildinggadgets2.common.network.PacketHandler;
+import com.direwolf20.buildinggadgets2.integration.AE2Integration;
+import com.direwolf20.buildinggadgets2.integration.AE2Methods;
+import com.direwolf20.buildinggadgets2.util.DimBlockPos;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.network.NetworkEvent;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/** Client asks for AE2 counts for all these items in one go; server replies with one PacketUpdateAE2Count. */
+public class PacketRequestAE2Count {
+    private final DimBlockPos boundPos;
+    private final List<ItemStack> stacks;
+
+    public PacketRequestAE2Count(DimBlockPos boundPos, List<ItemStack> stacks) {
+        this.boundPos = boundPos;
+        this.stacks = stacks;
+    }
+
+    public static void encode(PacketRequestAE2Count msg, FriendlyByteBuf buffer) {
+        buffer.writeBlockPos(msg.boundPos.blockPos);
+        buffer.writeResourceLocation(msg.boundPos.levelKey.location());
+        buffer.writeCollection(msg.stacks, FriendlyByteBuf::writeItem);
+    }
+
+    public static PacketRequestAE2Count decode(FriendlyByteBuf buffer) {
+        // Read order must match encode order
+        BlockPos pos = buffer.readBlockPos();
+        ResourceKey<Level> levelKey = ResourceKey.create(Registries.DIMENSION, buffer.readResourceLocation());
+        
+        return new PacketRequestAE2Count(
+            new DimBlockPos(levelKey, pos), // Order matches your DimBlockPos constructor
+            buffer.readCollection(ArrayList::new, FriendlyByteBuf::readItem)
+        );
+    }
+
+    public static void handle(PacketRequestAE2Count msg, Supplier<NetworkEvent.Context> context) {
+        context.get().enqueueWork(() -> {
+            ServerPlayer player = context.get().getSender();
+            if (player == null || !AE2Integration.isLoaded()) return;
+
+            Map<String, Integer> countsMap = new HashMap<>();
+            for (ItemStack stack : msg.stacks) {
+                long count = AE2Methods.countInAE2(msg.boundPos, player, stack);
+                String itemKey = ForgeRegistries.ITEMS.getKey(stack.getItem()).toString();
+                countsMap.put(itemKey, (int) count);
+            }
+
+            PacketHandler.sendTo(new PacketUpdateAE2Count(countsMap), player);
+        });
+        context.get().setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/direwolf20/buildinggadgets2/common/network/packets/PacketUpdateAE2Count.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/common/network/packets/PacketUpdateAE2Count.java
@@ -1,0 +1,44 @@
+package com.direwolf20.buildinggadgets2.common.network.packets;
+
+import com.direwolf20.buildinggadgets2.client.screen.MaterialListGUI;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraftforge.network.NetworkEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+
+/** Server sends this back with AE2 counts so the material list can show "available" without the client touching AE2. */
+public class PacketUpdateAE2Count {
+    // Cache so we can show counts on list refresh without re-asking the server. Cleared when the GUI closes.
+    public static Map<String, Integer> clientCache = new HashMap<>();
+    private final Map<String, Integer> counts;
+
+    public PacketUpdateAE2Count(Map<String, Integer> counts) {
+        this.counts = counts;
+    }
+
+    public static void encode(PacketUpdateAE2Count msg, FriendlyByteBuf buffer) {
+        buffer.writeMap(msg.counts, FriendlyByteBuf::writeUtf, FriendlyByteBuf::writeInt);
+    }
+
+    public static PacketUpdateAE2Count decode(FriendlyByteBuf buffer) {
+        return new PacketUpdateAE2Count(buffer.readMap(FriendlyByteBuf::readUtf, FriendlyByteBuf::readInt));
+    }
+
+    public static void handle(PacketUpdateAE2Count msg, Supplier<NetworkEvent.Context> context) {
+        context.get().enqueueWork(() -> {
+            msg.counts.forEach((key, count) -> {
+                clientCache.put(key, count);
+
+                if (Minecraft.getInstance().screen instanceof MaterialListGUI gui) {
+                    if (gui.getScrollingList() != null) {
+                        gui.getScrollingList().refreshItemCount(key, count);
+                    }
+                }
+            });
+        });
+        context.get().setPacketHandled(true);
+    }
+}

--- a/src/main/java/com/direwolf20/buildinggadgets2/integration/AE2Methods.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/integration/AE2Methods.java
@@ -73,6 +73,23 @@ public class AE2Methods {
         }
     }
 
+    /** How many of this item are in the grid (simulated extract). Used for the material list "available" column. */
+    public static long countInAE2(DimBlockPos boundInventory, Player player, ItemStack itemStack) {
+        Level level = boundInventory.getLevel(player.getServer());
+        if (level == null) return 0;
+        
+        BlockEntity blockEntity = level.getBlockEntity(boundInventory.blockPos);
+        if (!(blockEntity instanceof IWirelessAccessPoint accessPoint)) return 0;
+
+        IGrid grid = accessPoint.getGrid();
+        if (grid == null) return 0;
+
+        var inventory = grid.getStorageService().getInventory();
+        AEItemKey itemKey = AEItemKey.of(itemStack);
+
+        return inventory.extract(itemKey, Long.MAX_VALUE, Actionable.SIMULATE, IActionSource.ofPlayer(player));
+    }
+
     public static void checkAE2ForFluids(DimBlockPos boundInventory, Player player, FluidStack fluidStack, boolean simulate) {
         Level level = boundInventory.getLevel(player.getServer());
         if (level == null) return;

--- a/src/main/java/com/direwolf20/buildinggadgets2/util/BuildingUtils.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/util/BuildingUtils.java
@@ -325,6 +325,20 @@ public class BuildingUtils {
         return counter[0];
     }
 
+    // Player inventory count + AE2 grid count (when bound to a wireless point). Use this for the material list.
+    public static int countItemStacks(Player player, ItemStack itemStack, DimBlockPos boundInventory) {
+        if (itemStack.isEmpty() || itemStack.is(Items.AIR)) return 0;
+        final int[] counter = {0};
+
+        if (boundInventory != null && AE2Integration.isLoaded()) {
+            counter[0] += (int) com.direwolf20.buildinggadgets2.integration.AE2Methods.countInAE2(boundInventory, player, itemStack);
+        }
+
+        counter[0] += countItemStacks(player, itemStack);
+
+        return counter[0];
+    }
+
     public static void giveFluidToPlayer(Player player, FluidStack returnedFluid, DimBlockPos boundInventory, Direction direction) {
         //Check Bound Inventory First
         if (boundInventory != null) {


### PR DESCRIPTION
- Client requests AE2 counts in one bulk packet; server replies with
  one PacketUpdateAE2Count. Counts are cached and cleared when the
  GUI closes.
- Material list shows player inventory + AE2 for each item. List
  entries update when the response arrives.
- New packets: PacketRequestAE2Count, PacketUpdateAE2Count. 
    - AE2Methods gains countInAE2(); 
    - BuildingUtils gains countItemStacks(..., DimBlockPos).