### PR TITLE
Fix ArrayIndexOutOfBoundsException in BG2Data.statePosListToNBTMapArray

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ repositories {
 
     maven { //Curios-New
         name = "OctoStudios"
-        url = uri("https://maven.octo-studios.com/releases")
+        url = uri("https://maven.theillusivec4.top/")
         content {
             includeGroup "top.theillusivec4.curios"
         }

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,6 +31,6 @@ mod_description=We can build it better, stronger, faster.
 #Dependencies
 jei_mc_version=1.21.1
 jei_version=19.21.0.247
-curios_version=9.0.5+1.21
+curios_version=9.2.2+1.21.1
 ae2_version=19.0.20-beta
 patchouli_version=1.21-87-NEOFORGE-SNAPSHOT

--- a/src/main/java/com/direwolf20/buildinggadgets2/common/worlddata/BG2Data.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/common/worlddata/BG2Data.java
@@ -129,14 +129,20 @@ public class BG2Data extends SavedData {
         if (list == null || list.isEmpty()) return tag;
         ArrayList<BlockState> blockStateMap = StatePos.getBlockStateMap(list);
         ListTag blockStateMapList = StatePos.getBlockStateNBT(blockStateMap);
-        int[] blocklist = new int[list.size()];
-        final int[] counter = {0};
         BlockPos start = list.get(0).pos;
         BlockPos end = list.get(list.size() - 1).pos;
         AABB aabb = VecHelpers.aabbFromBlockPos(start, end);
 
+        // Fix: size the array based on the actual AABB volume, not list.size(),
+        // because betweenClosedStream(aabb) may yield more positions than the list contains.
+        int aabbCountX = (int) (Math.floor(aabb.maxX) - Math.floor(aabb.minX) + 1);
+        int aabbCountY = (int) (Math.floor(aabb.maxY) - Math.floor(aabb.minY) + 1);
+        int aabbCountZ = (int) (Math.floor(aabb.maxZ) - Math.floor(aabb.minZ) + 1);
+        int[] blocklist = new int[aabbCountX * aabbCountY * aabbCountZ];
+        final int[] counter = {0};
+
         Map<BlockPos, BlockState> blockStateByPos = list.stream()
-                .collect(Collectors.toMap(e -> e.pos, e -> e.state));
+                .collect(Collectors.toMap(e -> e.pos, e -> e.state, (a, b) -> b));
 
         BlockPos.betweenClosedStream(aabb).map(BlockPos::immutable).forEach(pos -> {
             BlockState blockState = blockStateByPos.get(pos);


### PR DESCRIPTION
## Problem

Open Issue: https://github.com/Direwolf20-MC/BuildingGadgets2/issues/237

I play ATM10 and tried to cut a structure from Ars Noveau with the Cut-Paste-Gadget.

The Bug can be recreated the same way:

- Newest ATM10 Version
- Cut-Paste-Gadget
- Try cutting on of the Ars Noveau Towers

The server crashes with `ArrayIndexOutOfBoundsException` when Building Gadgets 2 tries to save world data after using the copy/paste gadget on certain structures (e.g. Ars Nouveau multiblocks). The crash also triggers on shutdown, which can trap the server in a crash loop.

```
java.lang.ArrayIndexOutOfBoundsException: Index 20159 out of bounds for length 20159
    at com.direwolf20.buildinggadgets2.common.worlddata.BG2Data.lambda$statePosListToNBTMapArray$2(BG2Data.java:143)
```

## Cause

In `statePosListToNBTMapArray`, the `blocklist` array is allocated with `list.size()` elements, but the loop that fills it iterates over every position in the bounding box via `BlockPos.betweenClosedStream(aabb)`. When the AABB volume exceeds `list.size()` — which can happen when certain mod blocks cause a mismatch between the list length and the spatial bounds derived from `list.get(0)` / `list.get(list.size() - 1)` — the array overflows.

## Fix

Two changes in `BG2Data.java`:

1. **Size the array from the AABB volume** instead of `list.size()`, so it always matches the number of iterations in `BlockPos.betweenClosedStream(aabb)`.

2. **Add a merge function to `Collectors.toMap`** (`(a, b) -> b`) to gracefully handle duplicate `BlockPos` entries that some mod blocks can produce, instead of throwing `IllegalStateException`.

## Additional: Updated Curios Maven URL

The Curios Maven repository has moved from `maven.octo-studios.com` to `maven.theillusivec4.top` (see [[Curios README](https://github.com/TheIllusiveC4/Curios#adding-to-your-project)](https://github.com/TheIllusiveC4/Curios#adding-to-your-project)). The dependency version was also bumped from `9.0.5+1.21` to `9.2.2+1.21.1` since the old version was never published to the new repository. Without this change the project no longer compiles.

## Building from Source

Requires Java 21 (JDK).

```bash
git clone https://github.com/Direwolf20-MC/BuildingGadgets2.git
cd BuildingGadgets2
./gradlew build
```

If your server is stuck in a crash loop from this bug, delete `world/data/buildinggadgets2.dat` before starting.



Open for suggestions / comments <3
This is a personal fix, I build and run this on my own server.