### PR TITLE
Fix Connected Area option of Building Gadget's Surface mode

### DIFF
--- a/src/main/java/com/direwolf20/buildinggadgets2/util/modes/Surface.java
+++ b/src/main/java/com/direwolf20/buildinggadgets2/util/modes/Surface.java
@@ -43,7 +43,7 @@ public class Surface extends BaseMode {
         });
 
         boolean connected = GadgetNBT.getSetting(gadget, GadgetNBT.ToggleableSettings.CONNECTED_AREA.getName());
-        if (isExchanging && connected)
+        if (connected)
             return removeUnConnected(level, player, startAt.subtract(start), coordinates, hitSide);
         return coordinates;
     }


### PR DESCRIPTION
The code was previously checking for both `isExchanging` (to check if it's the Exchanging Gadget)  and `connected` (to check if the Connected Area option is enabled on the Building Gadget).

However, on the Building Gadget that will always be `false`, causing the Connected Area option to be ignored.

On a related note, looking at the code it seems this is also an issue on the 21.6 branch

Fixes #144 